### PR TITLE
Optionally pass signing keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         package:
         # - {name: "sway-git"}
         # - {name: "wlroots-git"}
-        # - {name: "dropbox", signing_keys: "FC918B335044912E"}
+        - {name: "dropbox", signing_keys: "FC918B335044912E"}
         - {name: "google-chrome"}
         - {name: "scaleway-cli"}
         - {name: "google-cloud-sdk"}
@@ -73,3 +73,4 @@ jobs:
       uses: ./
       with:
         package: "${{ matrix.package.name }}"
+        signing_keys: "${{ matrix.package.signing_keys }}"


### PR DESCRIPTION
Optionally pass signing keys to enable build of Dropbox and other packages with signed sources